### PR TITLE
Add support for pipeline-level `env`

### DIFF
--- a/pipeline/example_simple_pipeline_test.go
+++ b/pipeline/example_simple_pipeline_test.go
@@ -18,6 +18,9 @@ func Example_simple() {
 	p.Agents = agent.Agent{
 		"queue": "aws-spot-ubuntu-small",
 	}
+	p.Env = map[string]string{
+		"KEY": "Value",
+	}
 	jobA := step.Command{
 		Label:   str("job a"),
 		Key:     str("job-a"),
@@ -35,6 +38,9 @@ func Example_simple() {
 	// {
 	// 	"agents": {
 	// 		"queue": "aws-spot-ubuntu-small"
+	// 	},
+	// 	"env": {
+	// 		"KEY": "Value"
 	// 	},
 	// 	"steps": [
 	// 		{

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -9,9 +9,10 @@ type Step interface {
 type Slug string
 
 type Pipeline struct {
-	Slug   Slug        `json:"-"`
-	Agents agent.Agent `json:"agents,omitempty"`
-	Steps  []Step      `json:"steps"`
+	Slug   Slug              `json:"-"`
+	Agents agent.Agent       `json:"agents,omitempty"`
+	Env    map[string]string `json:"env,omitempty"`
+	Steps  []Step            `json:"steps"`
 }
 
 func New(s Slug) *Pipeline {


### PR DESCRIPTION
https://buildkite.com/docs/agent/v3/cli-pipeline#pipeline-format

So it's possible to specify environment variables for an entire pipeline.